### PR TITLE
Set port and lower test overhead to support CodeSanbox containers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  maxWorkers: '20%'
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,11 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  server: {
+    hmr: {
+      port: parseInt(process.env.KUBERNETES_SERVICE_PORT, 10) || 3000
+    }
+  },
   build: {
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),


### PR DESCRIPTION
https://github.com/rayfoss/feathers-pinia

# What should happen:
https://githubbox.com/rayfoss/feathers-pinia

- All 25 tests run in around 32 seconds
- Vue loads without hmr causing a refresh every 10 senconds

# what actually happens
https://githubbox.com/marshallswain/feathers-pinia

- Around 15 tests will eventually pass after 5 minutes
- 10 tests will fail due to a subprocess getting killed due to exhausted memory or something
- If you manually bypass the tests, Vue will load, but refreshes every 10 seconds

# Comments

If you'd like subpath imports and Node 16, add this `sandbox.config.json`

```
{
  "view": "terminal",
  "container": {
    "node": "16"
  }
}
```
