### PR TITLE
fix(build): updates build config to externalize vue-demi

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,11 +19,12 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['vue', 'pinia', 'lodash', 'sift'],
+      external: ['vue-demi', 'vue', 'pinia', 'lodash', 'sift'],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps
         globals: {
+          'vue-demi': 'VueDemi',
           vue: 'Vue',
           pinia: 'pinia',
           lodash: 'lodash',


### PR DESCRIPTION
### Context:

With the current build config, rollup outputs the following: 
```javascript
// dist/feathers-pinia.es.js

import { unref, computed, reactive, watch, toRefs, isRef } from "vue";
```

This fails for an app running in a vue2 environment, since in that case, imports should come from `"@vue/composition-api"` and not `"vue"`. What (to my knowledge) should be the desired output is:

```javascript
// dist/feathers-pinia.es.js

import { unref, computed, reactive, watch, toRefs, isRef } from "vue-demi";
```
so that the consuming application resolves to `"@vue/composition-api"` if vue2 detected, or else `"vue"` if vue3 detected by vue-demi.

### Issue:
Consuming `feathers-pinia` with vue2 applications was causing the following errors on running npm run dev (`vite`):
```
 > node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:9: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "unref"
    25 │ import { unref, computed, reactive, watch, toRefs, isRef } from "vue";
       ╵          ~~~~~

 > node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:16: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "computed"
    25 │ import { unref, computed, reactive, watch, toRefs, isRef } from "vue";
       ╵                 ~~~~~~~~

 > node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:26: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "reactive"
    25 │ import { unref, computed, reactive, watch, toRefs, isRef } from "vue";
       ╵                           ~~~~~~~~

 > node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:36: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "watch"
    25 │ import { unref, computed, reactive, watch, toRefs, isRef } from "vue";
       ╵                                     ~~~~~

 > node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:43: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "toRefs"
    25 │ import { unref, computed, reactive, watch, toRefs, isRef } from "vue";
       ╵                                            ~~~~~~

 > node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:51: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "isRef"
    25 │ import { unref, computed, reactive, watch, toRefs, isRef } from "vue";
       ╵                                                    ~~~~~

error when starting dev server:
Error: Build failed with 6 errors:
node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:9: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "unref"
node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:16: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "computed"
node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:26: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "reactive"
node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:36: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "watch"
node_modules/feathers-pinia/dist/feathers-pinia.es.js:25:43: error: No matching export in "node_modules/vue/dist/vue.runtime.esm.js" for import "toRefs"
...
```

The issue is in the build configuration specified in vite.config.ts (see also [here](https://github.com/vueuse/vue-demi/issues/69#issuecomment-877331251) and [here](https://github.com/vueuse/vue-demi/issues/108)).

### Solution:

Updating the build configuration to externalize 'vue-demi' and also adding it as a global fixes this, producing the desired output above:
```javascript
// vite.config.ts

 build: {
    lib: {
      entry: path.resolve(__dirname, 'src/index.ts'),
      name: 'feathersPinia',
    },
    sourcemap: true,
    rollupOptions: {
      // make sure to externalize deps that shouldn't be bundled
      // into your library
      external: ['vue-demi', 'vue', 'pinia', 'lodash', 'sift'],   // <----------- ADDED 'vue-demi'
      output: {
        // Provide global variables to use in the UMD build
        // for externalized deps
        globals: {
          'vue-demi': 'VueDemi',   // <----------- ADDED THIS LINE
          vue: 'Vue',
          pinia: 'pinia',
          lodash: 'lodash',
          sift: 'sift',
        },
      },
    },
  }
  ```