### PR TITLE
feat: support either defineStore(id, options) or defineStore(options)

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -23,7 +23,10 @@ export function setupFeathersPinia(globalOptions: SetupOptions) {
     registerClient(name, clients[name])
   })
 
-  function defineStoreWrapper(options: DefineStoreOptions) {
+  function defineStoreWrapper(...args: [DefineStoreOptions] | [string, DefineStoreOptions]) {
+    const id = args.length === 2 ? args[0] : args[0].id
+    const options = args.length === 2 ? args[1] : args[0]
+    options.id = id || `service.${options.servicePath}`
     return defineStore(Object.assign({}, globalOptions, options))
   }
 

--- a/tests/define-store.test.ts
+++ b/tests/define-store.test.ts
@@ -13,8 +13,7 @@ export const { defineStore, BaseModel } = setupFeathersPinia({
 
 class User extends BaseModel { }
 
-const useUsersStore = defineStore({
-  servicePath: 'users',
+const storeOptions = {
   Model: User,
   state: () => ({
     firstName: 'Bob',
@@ -22,24 +21,79 @@ const useUsersStore = defineStore({
     age: 20
   }),
   getters: {
-    fullName: state => `${state.firstName} ${state.lastName}`,
+    fullName: (state: any): string => `${state.firstName} ${state.lastName}`,
   },
   actions: {
-    greet() {
-      return `Hello ${this.fullName}`
+    greet(): string {
+      return 'Hello from action'
     }
   }
-})
-const store = useUsersStore(pinia)
+}
 
-describe('Define Users Store', () => {
+describe('Define Store 1 (from options without options.id)', () => {
+  const useUsersStore = defineStore({ servicePath: 'users', ...storeOptions })
+  const store = useUsersStore(pinia)
+
   test('can interact with store', async () => {
+    expect(store.$id).toBe('service.users')
+    expect(store.servicePath).toBe('users')
     expect(store.firstName).toBe('Bob')
     expect(store.fullName).toBe('Bob Smith')
-    expect(store.greet()).toBe('Hello Bob Smith')
+    expect(store.greet()).toBe('Hello from action')
     store.firstName = 'John'
     expect(store.firstName).toBe('John')
     expect(store.fullName).toBe('John Smith')
-    expect(store.greet()).toBe('Hello John Smith')
+    expect(store.greet()).toBe('Hello from action')
+  })
+})
+
+describe('Define Store 2 (from options with options.id)', () => {
+  const useUsersStore = defineStore({ id: 'users2', servicePath: 'users', ...storeOptions })
+  const store = useUsersStore(pinia)
+
+  test('can interact with store', async () => {
+    expect(store.$id).toBe('users2')
+    expect(store.servicePath).toBe('users')
+    expect(store.firstName).toBe('Bob')
+    expect(store.fullName).toBe('Bob Smith')
+    expect(store.greet()).toBe('Hello from action')
+    store.firstName = 'John'
+    expect(store.firstName).toBe('John')
+    expect(store.fullName).toBe('John Smith')
+    expect(store.greet()).toBe('Hello from action')
+  })
+})
+
+describe('Define Store 3 (from id and options without options.id)', () => {
+  const useUsersStore = defineStore('users3', { servicePath: 'users', ...storeOptions })
+  const store = useUsersStore(pinia)
+
+  test('can interact with store', async () => {
+    expect(store.$id).toBe('users3')
+    expect(store.servicePath).toBe('users')
+    expect(store.firstName).toBe('Bob')
+    expect(store.fullName).toBe('Bob Smith')
+    expect(store.greet()).toBe('Hello from action')
+    store.firstName = 'John'
+    expect(store.firstName).toBe('John')
+    expect(store.fullName).toBe('John Smith')
+    expect(store.greet()).toBe('Hello from action')
+  })
+})
+
+describe('Define Store 4 (from id and options with options.id)', () => {
+  const useUsersStore = defineStore('users4', { id: 'should-be-overriden', servicePath: 'users', ...storeOptions })
+  const store = useUsersStore(pinia)
+
+  test('can interact with store', async () => {
+    expect(store.$id).toBe('users4')
+    expect(store.servicePath).toBe('users')
+    expect(store.firstName).toBe('Bob')
+    expect(store.fullName).toBe('Bob Smith')
+    expect(store.greet()).toBe('Hello from action')
+    store.firstName = 'John'
+    expect(store.firstName).toBe('John')
+    expect(store.fullName).toBe('John Smith')
+    expect(store.greet()).toBe('Hello from action')
   })
 })


### PR DESCRIPTION
This PR adds support for passing either two arguments `defineStore(id, options)` or a single one `defineStore(options)` to better align this with pinia. Tests are updated and passing to cover for 4 cases:
1. `defineStore({ servicePath: 'users', ... })`
2. `defineStore({ id: 'users2', servicePath: 'users', ... })`
3. `defineStore('users3', { servicePath: 'users', ... })`
4. `defineStore('users4', { id: 'should-be-overriden', servicePath: 'users', ... })`

Closes #16