### PR TITLE
WIP: feat: authStore fully typed

### DIFF
--- a/src/define-auth-store.ts
+++ b/src/define-auth-store.ts
@@ -1,27 +1,75 @@
-import { defineStore } from 'pinia'
+import { defineStore, DefineStoreOptionsBase, PiniaCustomProperties, StateTree, Store, StoreDefinition, _GettersTree, _StoreWithGetters, _StoreWithState } from 'pinia'
+import { UnwrapRef } from "vue-demi";
 
-interface SetupAuthOptions {
+interface DefineAuthStoreOptions<
+  Id extends string,
+  S extends StateTree,
+  G /* extends GettersTree<S> */,
+  A /* extends Record<string, StoreAction> */
+> extends DefineStoreOptionsBase<S, Store<Id, S, G, A>> {
   feathersClient: any
-  id?: string
-  state?: Function
-  getters?: { [k: string]: any }
-  actions?: { [k: string]: any }
+  id?: Id
+  state?: () => S
+
+  getters?: G &
+     ThisType<UnwrapRef<AS<S>> & _StoreWithGetters<AS<S>> & PiniaCustomProperties> &
+     _GettersTree<S>
+ 
+   actions?: A &
+     ThisType<
+       A &
+         UnwrapRef<AS<S>> &
+         _StoreWithState<Id, AS<S>, AG<G>, AA<A>> &
+         _StoreWithGetters<AG<G>> &
+         PiniaCustomProperties
+     >
 }
 
-export function defineAuthStore(...args: [SetupAuthOptions] | [string, SetupAuthOptions]): any {
+interface AuthStoreDefaultState {
+  isLoading: boolean,
+  isAuthenticated: boolean,
+  accessToken: string | null, // The auth0 and API accessToken
+  payload: any, // accessToken payload
+  error: any,
+}
+
+interface AuthStoreDefaultGetters extends _GettersTree<AuthStoreDefaultState> {
+  feathersClient: () => any
+}
+
+interface AuthStoreDefaultActions {
+  authenticate: (authData: any) => Promise<any>
+  handleResponse: (response: any) => any
+  handleError: (err: Error) => any
+  setLoaded: (val: boolean) => void
+}
+
+type AS<S> = AuthStoreDefaultState & S;
+type AG<G> = AuthStoreDefaultGetters & G
+type AA<A> = AuthStoreDefaultActions & A;
+
+export function defineAuthStore<
+  Id extends string,
+  S extends StateTree = {},
+  G extends _GettersTree<S> = {},
+  // cannot extends ActionsTree because we loose the typings
+  A /* extends ActionsTree */ = {}
+>(
+  ...args: [DefineAuthStoreOptions<Id, S, G, A>] | [Id, Omit<DefineAuthStoreOptions<Id, S, G, A>, 'id'>]
+): StoreDefinition<Id, AS<S>, AG<G>, AA<A>> {
   const id = args.length === 2 ? args[0] : args[0].id || 'auth'
   const options = args.length === 2 ? args[1] : args[0]
   const {
     feathersClient,
-    state = () => ({}),
-    getters = {},
-    actions = {},
+    state = () => ({}) as S,
+    getters = {} as G,
+    actions = {} as A,
   } = options
 
   /**
    * Default State
    */
-  const defaultState = {
+  const defaultState: AuthStoreDefaultState = {
     isLoading: true,
     isAuthenticated: false,
     accessToken: null, // The auth0 and API accessToken
@@ -29,7 +77,10 @@ export function defineAuthStore(...args: [SetupAuthOptions] | [string, SetupAuth
     error: null,
   }
 
-  const defaultGetters = {
+  /**
+   * Default Getters
+   */
+  const defaultGetters: AuthStoreDefaultGetters = {
     feathersClient() {
       return feathersClient
     },
@@ -38,7 +89,7 @@ export function defineAuthStore(...args: [SetupAuthOptions] | [string, SetupAuth
   /**
    * Default Actions
    */
-  const defaultActions = {
+  const defaultActions: AuthStoreDefaultActions = {
     async authenticate(authData: any) {
       try {
         const response = await feathersClient.authenticate(authData)
@@ -68,16 +119,16 @@ export function defineAuthStore(...args: [SetupAuthOptions] | [string, SetupAuth
      * For tracking first-load state. Used by the watcher, below.
      */
     setLoaded() {
-      // eslint-disable-next-line @typescript-eslint/no-extra-semi
-      ;(this as any).isLoading = false
+      (this as any).isLoading = false
     },
   }
 
   const useAuth = defineStore({
-    id,
+    id: id as Id,
     state: () => Object.assign(defaultState, state()),
     getters: Object.assign(defaultGetters, getters),
     actions: Object.assign(defaultActions, actions),
   })
+
   return useAuth
 }

--- a/tests/define-auth-store.test.ts
+++ b/tests/define-auth-store.test.ts
@@ -68,7 +68,7 @@ describe('Define Auth Store 3 (from id and options without options.id)', () => {
 })
 
 describe('Define Auth Store 4 (from id and options with options.id)', () => {
-  const useAuth = defineAuthStore('auth4', { id: 'should-be-overriden', feathersClient: api })
+  const useAuth = defineAuthStore('auth4', { feathersClient: api })
   const store = useAuth(pinia)
   test('can authenticate', async () => {
     const response = await store.authenticate({ strategy: 'jwt', accessToken: 'hi' })


### PR DESCRIPTION
Following up #1 and #4. To make smaller PRs instead of big #4 typing PR:

This PR aims to type the auth store. I think I got it fully working. Here are some screenshots:

At definition, getters have full context of `this`. See the default state and the custom `testState`:
<img width="731" alt="Bildschirmfoto 2022-01-26 um 00 15 22" src="https://user-images.githubusercontent.com/22286818/151076250-0bc867f5-ed41-469f-a73a-5efc62953a3d.png">

Same as getters, at definition, actions have full context of `this`. See the default stuff and custom stuff:
<img width="731" alt="Bildschirmfoto 2022-01-26 um 00 16 21" src="https://user-images.githubusercontent.com/22286818/151076362-f787fd8c-bde7-4766-83a5-91b9d15a6710.png">

At usage, tore properties are properly defined:
<img width="731" alt="Bildschirmfoto 2022-01-26 um 00 17 03" src="https://user-images.githubusercontent.com/22286818/151076457-ff9d4f59-daf5-44b9-9412-a508a9279bbb.png">


I'd like to export some interfaces/types. At leas `AuthStoreDefaultState`, `AuthStoreDefaultGetters`, `AuthStoreDefaultActions`.
It would be nice to have `import { AuthStoreDefaultState } from 'feathers-pinia'`. This comes in handy sometimes.
In my libraries I use `export * from './types'`. What do you think of that, marshall? I think about combining `./src/types.ts` and `./src/service-store/types.ts` somehow. This was also requested at `feathers-vuex` somewhere (can not find it now). ATM I have some imported types like:
```
import { ModelStatic, Model } from "feathers-vuex/dist/service-module/types";
```
While getting the types right, I would like to straighten that.