### PR TITLE
feat: usePagination itemsCount

### DIFF
--- a/docs/guide/use-pagination.md
+++ b/docs/guide/use-pagination.md
@@ -56,6 +56,7 @@ const {
   canNext,
   canPrev,
   currentPage,
+  itemsCount,
   pageCount,
   toPage,
   toStart,
@@ -72,6 +73,7 @@ The return value from `usePagination` is an object containing these 9 utilities:
 - `canNext {Computed<Boolean>}` will be `true` if there is a next page. If it's false, you can style a "Next Page" button to let the user know the that the functionality is not available.
 - `canPrev {Computed<Boolean>}` will be `true if there is a previous page. If it's false, you can style a "Previous Page" button to let the user know that the functionality is not available.
 - `currentPage {Computed<Number>}` is the current page number in the overall set of results.
+- `itemsCount {Computed<Number>}` is the total number of items in the overall set of results.
 - `pageCount {Computed<Number>}` is the total number of pages that are available in the set of results.
 - `toPage(pageNumber) {Function}` navigates to the page number provided as the first argument.
 - `toStart() {Function}` goes to the first page.

--- a/src/use-pagination.ts
+++ b/src/use-pagination.ts
@@ -2,6 +2,18 @@ import { computed, watch, Ref, unref } from 'vue-demi'
 
 export function usePagination(pagination: any, latestQuery: Ref) {
   /**
+   * The number of items returned in the latestQuery prop.
+   */
+   const itemsCount = computed(() => {
+    const q = unref(latestQuery)
+    if (q && q.response) {
+      return q.response.total
+    } else {
+      return 0
+    }
+  })
+
+  /**
    * The number of pages available based on the results returned in the latestQuery prop.
    */
   const pageCount = computed(() => {
@@ -80,6 +92,7 @@ export function usePagination(pagination: any, latestQuery: Ref) {
   }
 
   return {
+    itemsCount,
     pageCount,
     currentPage,
     canPrev,

--- a/tests/use-pagination.test.ts
+++ b/tests/use-pagination.test.ts
@@ -88,11 +88,12 @@ describe('usePagination', () => {
 
     await timeout(200)
 
-    const { currentPage, pageCount, next, canNext, canPrev } = usePagination(
+    const { currentPage, itemsCount, pageCount, next, canNext, canPrev } = usePagination(
       pagination,
       latestQuery,
     )
     expect(currentPage.value).toBe(1)
+    expect(itemsCount.value).toBe(totalItems)
     expect(pageCount.value).toBe(Math.ceil(totalItems / pageLimit))
     expect(canNext.value).toBeTruthy()
     expect(canPrev.value).toBeFalsy()


### PR DESCRIPTION
I use a computed value from `latestQuery` in all of my projects that uses pagination. I think it's better to have it directly inside this package. It's useful to know for large table, when searching or filtering, we get to see the `itemsCount` for a given query.