### PR TITLE
fix: create, update, and patch on a clone will return a clone

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     'max-len': [
       'error',
       {
-        code: 100,
+        code: 120,
         ignoreStrings: true,
         ignoreTemplateLiterals: true,
         ignoreComments: true,

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,7 @@
   "tabWidth": 2,
   "useTabs": false,
   "semi": false,
-  "printWidth": 100,
+  "printWidth": 120,
   "singleQuote": true,
   "arrowParens": "always",
   "trailingComma": "all"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.rulers": [100],
   "html.format.wrapLineLength": 100,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "vitest.enable": true
 }

--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -34,6 +34,38 @@ If your app will use feathers-rest (no realtime connection), install these packa
 
 Vite will work without any configuration. Instructions for Quasar, Nuxt, and Vue CLI are yet to be determined.
 
+### TypeScript
+
+By default, TypeScript will expect you to strictly identify properties on Model classes.  See the `!` in the following example:
+
+```ts
+class UserModel extends BaseModel {
+  foo!: string
+  bar!: number
+}
+```
+
+You can optionally configure TypeScript to not require the `!` on every property in your `tsconfig.json`. The `strictPropertyInitialization` property goes at the top level of the config, and not in the `compilerOptions`:
+
+```json
+{
+  "strictPropertyInitialization": false,
+  "compilerOptions": {
+    // not in here
+  },
+}
+```
+
+With `strictPropertyInitialization` turned off, you can declare class properties as normal:
+
+```ts
+// No `!` needed after every property
+class UserModel extends BaseModel {
+  foo: string
+  bar: number
+}
+```
+
 ## Setup
 
 ### Feathers Client(s)

--- a/src/service-store/base-model.ts
+++ b/src/service-store/base-model.ts
@@ -21,7 +21,7 @@ export class BaseModel implements AnyData {
 
   constructor(data: AnyData, options: ModelInstanceOptions = {}) {
     const ctor = this.constructor as ModelStatic<BaseModel>
-    const { store, instanceDefaults, setupInstance } = ctor;
+    const { store, instanceDefaults, setupInstance } = ctor
     Object.assign(this, instanceDefaults.call(ctor, data, { models, store }))
     Object.assign(this, setupInstance.call(ctor, data, { models, store }))
     this.__isClone = !!options.clone
@@ -30,26 +30,20 @@ export class BaseModel implements AnyData {
   }
 
   public static instanceDefaults<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    data: AnyData, 
-    options?: InstanceModifierOptions
+    this: ModelStatic<M>,
+    data: AnyData,
+    options?: InstanceModifierOptions,
   ): AnyData
-  public static instanceDefaults<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    data: AnyData
-  ): AnyData {
+  public static instanceDefaults<M extends BaseModel>(this: ModelStatic<M>, data: AnyData): AnyData {
     return data
   }
 
   public static setupInstance<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    data: AnyData, 
-    options?: InstanceModifierOptions
+    this: ModelStatic<M>,
+    data: AnyData,
+    options?: InstanceModifierOptions,
   ): AnyData
-  public static setupInstance<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    data: AnyData
-  ): AnyData {
+  public static setupInstance<M extends BaseModel>(this: ModelStatic<M>, data: AnyData): AnyData {
     return data
   }
 
@@ -60,121 +54,98 @@ export class BaseModel implements AnyData {
   public static addEventListener<M extends BaseModel>(
     this: ModelStatic<M>,
     eventName: string | symbol,
-    listener: (...args: any[]) => void
+    listener: (...args: any[]) => void,
   ) {
     this.emitter.addListener(eventName, listener)
-    return this;
+    return this
   }
 
-  public static emit<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    eventName: string | symbol,
-    ...args: any[]
-  ) {
+  public static emit<M extends BaseModel>(this: ModelStatic<M>, eventName: string | symbol, ...args: any[]) {
     return this.emitter.emit(eventName, ...args)
   }
 
-  public static eventNames<M extends BaseModel>(
-    this: ModelStatic<M>
-  ) {
+  public static eventNames<M extends BaseModel>(this: ModelStatic<M>) {
     return this.emitter.eventNames()
   }
 
-  public static getMaxListeners<M extends BaseModel>(
-    this: ModelStatic<M>
-  ) {
+  public static getMaxListeners<M extends BaseModel>(this: ModelStatic<M>) {
     return this.emitter.getMaxListeners()
   }
 
-  public static listenerCount<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    eventName: string | symbol
-  ) {
-    return this.emitter.listenerCount(eventName);
+  public static listenerCount<M extends BaseModel>(this: ModelStatic<M>, eventName: string | symbol) {
+    return this.emitter.listenerCount(eventName)
   }
 
-  public static listeners<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    eventName: string | symbol
-  ) {
+  public static listeners<M extends BaseModel>(this: ModelStatic<M>, eventName: string | symbol) {
     return this.emitter.listeners(eventName)
   }
 
   public static off<M extends BaseModel>(
     this: ModelStatic<M>,
     eventName: string | symbol,
-    listener: (...args: any[]) => void
+    listener: (...args: any[]) => void,
   ) {
     this.emitter.off(eventName, listener)
-    return this;
+    return this
   }
 
   public static on<M extends BaseModel>(
     this: ModelStatic<M>,
     eventName: string | symbol,
-    listener: (...args: any[]) => void
+    listener: (...args: any[]) => void,
   ) {
     this.emitter.on(eventName, listener)
-    return this;
+    return this
   }
 
   public static once<M extends BaseModel>(
     this: ModelStatic<M>,
     eventName: string | symbol,
-    listener: (...args: any[]) => void
+    listener: (...args: any[]) => void,
   ) {
     this.emitter.once(eventName, listener)
-    return this;
+    return this
   }
 
   public static prependListener<M extends BaseModel>(
     this: ModelStatic<M>,
     eventName: string | symbol,
-    listener: (...args: any[]) => void
+    listener: (...args: any[]) => void,
   ) {
     this.emitter.prependListener(eventName, listener)
-    return this;
+    return this
   }
 
   public static prependOnceListener<M extends BaseModel>(
     this: ModelStatic<M>,
     eventName: string | symbol,
-    listener: (...args: any[]) => void
+    listener: (...args: any[]) => void,
   ) {
     this.emitter.prependOnceListener(eventName, listener)
-    return this;
+    return this
   }
 
-  public static rawListeners<M extends BaseModel>(
-    this: ModelStatic<M>,
-    eventName: string | symbol
-    ) {
+  public static rawListeners<M extends BaseModel>(this: ModelStatic<M>, eventName: string | symbol) {
     return this.emitter.rawListeners(eventName)
   }
 
-  public static removeAllListeners<M extends BaseModel>(
-    this: ModelStatic<M>,
-    eventName?: string | symbol
-    ) {
+  public static removeAllListeners<M extends BaseModel>(this: ModelStatic<M>, eventName?: string | symbol) {
     this.emitter.removeAllListeners(eventName)
-    return this;
+    return this
   }
 
   public static removeListener<M extends BaseModel>(
     this: ModelStatic<M>,
-    eventName: string | symbol, 
-    listener: (...args: any[]) => void
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
   ) {
     this.emitter.removeListener(eventName, listener)
-    return this;
+    return this
   }
 
-  public static setMaxListeners<M extends BaseModel>(
-    this: ModelStatic<M>,
-    n: number
-  ) {
+  public static setMaxListeners<M extends BaseModel>(this: ModelStatic<M>, n: number) {
     this.emitter.setMaxListeners(n)
-    return this;
+    return this
   }
 
   //#endregion
@@ -200,27 +171,13 @@ export class BaseModel implements AnyData {
   public static addToStore<M extends BaseModel>(this: ModelStatic<M>, data: AnyDataOrArray) {
     return this.store.addToStore(data)
   }
-  public static update<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    id: Id, 
-    data: AnyData, 
-    params?: Params
-  ) {
-    return this.store.update(id, data, params);
+  public static update<M extends BaseModel>(this: ModelStatic<M>, id: Id, data: AnyData, params?: Params) {
+    return this.store.update(id, data, params)
   }
-  public static patch<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    id: NullableId, 
-    data: AnyData, 
-    params?: Params
-  ) {
-    return this.store.patch(id, data, params);
+  public static patch<M extends BaseModel>(this: ModelStatic<M>, id: NullableId, data: AnyData, params?: Params) {
+    return this.store.patch(id, data, params)
   }
-  public static remove<M extends BaseModel>(
-    this: ModelStatic<M>, 
-    id: NullableId, 
-    params?: Params
-  ) {
+  public static remove<M extends BaseModel>(this: ModelStatic<M>, id: NullableId, params?: Params) {
     return this.store.remove(id, params)
   }
   public static removeFromStore<M extends BaseModel>(this: ModelStatic<M>, data: AnyDataOrArray) {
@@ -236,7 +193,8 @@ export class BaseModel implements AnyData {
     const { store } = this.constructor as ModelStatic<BaseModel>
     const pending = store.pendingById[getId(this)]
     return pending?.create || pending?.update || pending?.patch || false
-  }  get isCreatePending(): boolean {
+  }
+  get isCreatePending(): boolean {
     const { store } = this.constructor as ModelStatic<BaseModel>
     return store.pendingById[getId(this)]?.create || false
   }

--- a/src/service-store/base-model.ts
+++ b/src/service-store/base-model.ts
@@ -229,15 +229,14 @@ export class BaseModel implements AnyData {
 
   get __isTemp() {
     const { idField } = this.constructor as ModelStatic<BaseModel>
-    return getId(this, idField) != null
+    return getId(this, idField) == null
   }
 
   get isSavePending() {
     const { store } = this.constructor as ModelStatic<BaseModel>
     const pending = store.pendingById[getId(this)]
     return pending?.create || pending?.update || pending?.patch || false
-  }
-  get isCreatePending(): boolean {
+  }  get isCreatePending(): boolean {
     const { store } = this.constructor as ModelStatic<BaseModel>
     return store.pendingById[getId(this)]?.create || false
   }

--- a/src/service-store/base-model.ts
+++ b/src/service-store/base-model.ts
@@ -264,31 +264,29 @@ export class BaseModel implements AnyData {
   public save(params?: any): Promise<this> {
     const { idField } = this.constructor as ModelStatic<BaseModel>
     const id = getId(this, idField)
-    if (id != null) {
-      return this.patch(params)
-    } else {
-      return this.create(params)
-    }
+    return id != null ? this.patch(params) : this.create(params)
   }
 
   /**
    * Calls service create with the current instance data
    * @param params
    */
-  public create(params?: any): Promise<this> {
+  public async create(params?: any): Promise<this> {
     const { idField, store } = this.constructor as ModelStatic<BaseModel>
     const data: any = Object.assign({}, this)
     if (data[idField] === null) {
       delete data[idField]
     }
-    return store.create(data, params) as Promise<this>
+    const { __isClone } = this
+    const saved = (await store.create(data, params)) as this
+    return __isClone ? saved.clone() : saved
   }
 
   /**
    * Calls service patch with the current instance data
    * @param params
    */
-  public patch(params?: any): Promise<this> {
+  public async patch(params?: any): Promise<this> {
     const { idField, store } = this.constructor as ModelStatic<BaseModel>
     const id = getId(this, idField)
 
@@ -298,14 +296,16 @@ export class BaseModel implements AnyData {
       )
       return Promise.reject(error)
     }
-    return store.patch(id, this, params) as Promise<this>
+    const { __isClone } = this
+    const saved = (await store.patch(id, this, params)) as this
+    return __isClone ? saved.clone() : saved
   }
 
   /**
    * Calls service update with the current instance data
    * @param params
    */
-  public update(params?: any): Promise<this> {
+  public async update(params?: any): Promise<this> {
     const { idField, store } = this.constructor as ModelStatic<BaseModel>
     const id = getId(this, idField)
 
@@ -315,7 +315,9 @@ export class BaseModel implements AnyData {
       )
       return Promise.reject(error)
     }
-    return store.update(id, this, params) as Promise<this>
+    const { __isClone } = this
+    const saved = (await store.update(id, this, params)) as this
+    return __isClone ? saved.clone() : saved
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,7 +109,7 @@ export function assignTempId(item: any, tempIdField: string) {
  */
 export function cleanData<T = AnyDataOrArray>(data: T, tempIdField: string): T {
   const { items, isArray } = getArray(data)
-  const cleaned = items.map(item => _.omit(item, '__isClone', tempIdField))
+  const cleaned = items.map((item) => _.omit(item, '__isClone', tempIdField))
 
   return isArray ? cleaned : cleaned[0]
 }
@@ -163,10 +163,18 @@ export function getArray<T>(data: T | T[]) {
   return { items: isArray ? data : [data], isArray }
 }
 
-export const hasOwn = (obj: AnyData, prop: string) =>
-  Object.prototype.hasOwnProperty.call(obj, prop)
+export const hasOwn = (obj: AnyData, prop: string) => Object.prototype.hasOwnProperty.call(obj, prop)
 
 export function getSaveParams(params?: MaybeRef<Params>): Params {
-  if (!params) { return {} }
-  return fastCopy(unref(params));
+  if (!params) {
+    return {}
+  }
+  return fastCopy(unref(params))
+}
+export function markAsClone<T>(item: T) {
+  Object.defineProperty(item, '__isClone', {
+    value: true,
+    enumerable: false,
+  })
+  return item
 }

--- a/tests/model-instance-clone-and-commit.test.ts
+++ b/tests/model-instance-clone-and-commit.test.ts
@@ -6,12 +6,14 @@ const pinia = createPinia()
 
 const { defineStore, BaseModel } = setupFeathersPinia({ clients: { api } })
 
-class UserModel extends BaseModel {
+class Message extends BaseModel {
+  id: string
+  foo: any
   additionalData: any
 }
 
 const servicePath = 'messages'
-const useMessagesService = defineStore({ servicePath, Model: UserModel })
+const useMessagesService = defineStore({ servicePath, Model: Message })
 
 const messagesService = useMessagesService(pinia)
 
@@ -49,5 +51,84 @@ describe('Clone & commit', () => {
 
     expect(reset.foo).toBeUndefined()
     expect(clone === reset).toBeTruthy()
+  })
+
+  test('items and clones point to values in store', async () => {
+    const item = await messagesService.create({
+      id: 5,
+      text: 'Quick, what is the number to 911?',
+    })
+    const itemInStore = messagesService.itemsById[item.id]
+    expect(item).toEqual(itemInStore)
+
+    const clone = item.clone()
+    const cloneInStore = messagesService.clonesById[clone.id]
+    expect(clone).toEqual(cloneInStore)
+  })
+
+  describe('saving clones', () => {
+    test('saving a clone gives back a fresh clone', async () => {
+      const item = await messagesService.create({
+        id: 5,
+        text: 'Quick, what is the number to 911?',
+      })
+
+      const clone = item.clone()
+      expect(clone.__isClone).toBe(true)
+
+      const savedClone = await clone.save()
+      const cloneInStore = messagesService.clonesById[clone.id]
+
+      expect(savedClone.__isClone).toBe(true)
+      expect(savedClone).toEqual(cloneInStore)
+    })
+
+    test('calling .create() on a clone gives back a fresh clone', async () => {
+      const item = new Message({
+        id: 5,
+        text: 'Quick, what is the number to 911?',
+      })
+
+      const clone = item.clone()
+      expect(clone.__isClone).toBe(true)
+
+      const savedClone = await clone.create()
+      const cloneInStore = messagesService.clonesById[clone.id]
+
+      expect(savedClone.__isClone).toBe(true)
+      expect(savedClone).toEqual(cloneInStore)
+    })
+
+    test('calling .patch() on a clone gives back a fresh clone', async () => {
+      const item = new Message({
+        id: 5,
+        text: 'Quick, what is the number to 911?',
+      })
+
+      const clone = item.clone()
+      expect(clone.__isClone).toBe(true)
+
+      const savedClone = await clone.patch()
+      const cloneInStore = messagesService.clonesById[clone.id]
+
+      expect(savedClone.__isClone).toBe(true)
+      expect(savedClone).toEqual(cloneInStore)
+    })
+
+    test('calling .update() on a clone gives back a fresh clone', async () => {
+      const item = new Message({
+        id: 5,
+        text: 'Quick, what is the number to 911?',
+      })
+
+      const clone = item.clone()
+      expect(clone.__isClone).toBe(true)
+
+      const savedClone = await clone.update()
+      const cloneInStore = messagesService.clonesById[clone.id]
+
+      expect(savedClone.__isClone).toBe(true)
+      expect(savedClone).toEqual(cloneInStore)
+    })
   })
 })

--- a/tests/model-temps.test.ts
+++ b/tests/model-temps.test.ts
@@ -13,58 +13,66 @@ const useTodosService = defineStore({ servicePath: 'todos', tempIdField: '__cust
 const messagesService = useMessagesService(pinia)
 const todosService = useTodosService(pinia)
 
-const storesToTest = [{
-  servicePath: 'messages',
-  store: messagesService,
-  expectedTempIdField: '__tempId'
-}, {
-  servicePath: 'todos',
-  store: todosService,
-  expectedTempIdField: '__customTempId'
-}]
+const storesToTest = [
+  {
+    servicePath: 'messages',
+    store: messagesService,
+    expectedTempIdField: '__tempId',
+  },
+  {
+    servicePath: 'todos',
+    store: todosService,
+    expectedTempIdField: '__customTempId',
+  },
+]
 
 storesToTest.forEach(({ servicePath, store, expectedTempIdField }, i) => {
   const reset = () => resetStores(api.service(servicePath), store)
   describe(`Temporary Records (Local-Only) - ${i === 0 ? 'default' : 'custom'} tempIdField`, () => {
     beforeEach(() => reset())
     afterEach(() => reset())
-  
+
     test('default tempIdField is __tempId', () => {
       expect(store).toHaveProperty('tempIdField')
       expect(store.tempIdField).toBe(expectedTempIdField)
     })
-  
+
     test('records without idField get tempIdField added', () => {
       const item = store.addToStore({ text: 'this is a test' })
       const { tempIdField } = store
       expect(typeof item[tempIdField]).toBe('string')
     })
-  
+
+    test('records without idField have __isTemp of true', () => {
+      const item = store.addToStore({ text: 'this is a test' })
+      expect(item.__isTemp).toBe(true)
+    })
+
     test('records with idField do not get tempIdField added', () => {
       const item = store.addToStore({ id: 2, text: 'this is a test' })
       const { tempIdField } = store
       expect(item[tempIdField]).toBeUndefined()
     })
-  
+
     test('temps can be retrieved with getFromStore', () => {
       const item = store.addToStore({ text: 'this is a test' })
       const { tempIdField } = store
       const fromTempStore = store.getFromStore(item[tempIdField])
-      expect(fromTempStore[tempIdField]).toBe(item[tempIdField])
+      expect(fromTempStore?.[tempIdField]).toBe(item[tempIdField])
     })
-  
+
     test('temps are added to tempsById', () => {
       const item = store.addToStore({ text: 'this is a test' })
       const { tempIdField } = store
       expect(store.tempsById).toHaveProperty(item[tempIdField])
     })
-  
+
     test('saving a temp removes tempIdField', async () => {
       const item = await store.addToStore({ text: 'this is a test' }).save()
       const { tempIdField } = store
       expect(item[tempIdField]).toBeUndefined()
     })
-  
+
     test('saving a temp removes it from tempsById', async () => {
       let item = store.addToStore({ text: 'this is a test' })
       const { tempIdField } = store
@@ -72,19 +80,19 @@ storesToTest.forEach(({ servicePath, store, expectedTempIdField }, i) => {
       item = await item.save()
       expect(store.tempsById).not.toHaveProperty(tempId)
     })
-  
+
     test('find getter returns temps when params.temps === true', async () => {
       store.addToStore({ text: 'this is a test' })
       const data = store.findInStore({ query: {}, temps: true }).data
       expect(data.length).toBe(1)
     })
-  
+
     test('find getter does not returns temps when params.temps is falsy', async () => {
       store.addToStore({ text: 'this is a test' })
       const data = store.findInStore({ query: {} }).data
       expect(data.length).toBe(0)
     })
-  
+
     test('temps can be removed from the store', async () => {
       const item = store.addToStore({ text: 'this is a test' })
       const { tempIdField } = store
@@ -92,14 +100,14 @@ storesToTest.forEach(({ servicePath, store, expectedTempIdField }, i) => {
       item.removeFromStore()
       expect(store.tempsById).not.toHaveProperty(tempId)
     })
-  
+
     test('can clone a temp', () => {
       const item = store.addToStore({ text: 'this is a test' })
       item.clone()
       const { tempIdField } = store
       expect(store.clonesById).toHaveProperty(item[tempIdField])
     })
-  
+
     test('can commit a temp clone', () => {
       const item = store.addToStore({ text: 'this is a test' })
       item.clone({ foo: 'bar' }).commit()
@@ -107,4 +115,4 @@ storesToTest.forEach(({ servicePath, store, expectedTempIdField }, i) => {
       expect(store.tempsById[item[tempIdField]]).toHaveProperty('foo')
     })
   })
-});
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,6 @@
     "types": ["vite/client", "node", "vitest/globals"],
     "declaration": true
   },
+  "strictPropertyInitialization": false,
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
 }


### PR DESCRIPTION
Includes the following changes:

- Documents working with `strictPropertyInitialization` in `tsconfig.json`.
- Updates prettier's `printWidth` to 120 to prevent unnecessary formatting.
- Fixes a bug where `instance.__isClone` was the opposite of what it should have been. Includes test.
- Closes #52 