### PR TITLE
chore: reference types in package #61

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
       "require": "./dist/feathers-pinia.umd.js"
     }
   },
+  "types": "src/",
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs; npm run docs:copy-assets",


### PR DESCRIPTION
`package.json` no longer references typescript `"types"` folder since the line was [removed in a previous commit](https://github.com/marshallswain/feathers-pinia/compare/v0.36.2...v0.36.3#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16) with the addition of [vite-plugin-dts](https://github.com/alloc/vite-dts).