### PR TITLE
refactor: simplify define store

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
 export { setupFeathersPinia } from './setup'
-export { defineStore } from './service-store/define-store'
+export { defineStore, BaseModel } from './service-store'
 export { defineAuthStore } from './define-auth-store'
-export { makeServiceStore, BaseModel } from './service-store/index'
 export { associateFind } from './associate-find'
 export { associateGet } from './associate-get'
-export { makeState } from './service-store/make-state'
 
 export { models } from './models'
 export { clients, registerClient } from './clients'

--- a/src/service-store/index.ts
+++ b/src/service-store/index.ts
@@ -1,23 +1,3 @@
-import { ServiceOptions } from './types'
-import { makeState } from './make-state'
-import { makeGetters } from './make-getters'
-import { makeActions } from './make-actions'
-import { BaseModel } from './base-model'
-import { StateTree, _GettersTree } from 'pinia'
-
-export { makeState, makeGetters, makeActions, BaseModel }
-
-export function makeServiceStore<
-  Id extends string,
-  M extends BaseModel = BaseModel,
-  S extends StateTree = StateTree,
-  G extends _GettersTree<S> = {},
-  A = {},
->(options: ServiceOptions<Id, M, S, G, A>) {
-  return {
-    id: options.id,
-    state: makeState(options),
-    getters: makeGetters(options),
-    actions: makeActions(options),
-  }
-}
+export * from './base-model'
+export * from './types'
+export * from './define-store'

--- a/src/service-store/make-actions.ts
+++ b/src/service-store/make-actions.ts
@@ -52,7 +52,7 @@ type ServiceStoreTypedActions<M extends BaseModel = BaseModel> = TypedActions<
 
 export function makeActions<
   M extends BaseModel = BaseModel,
-  S extends StateTree = StateTree,
+  S extends StateTree = {},
   G extends _GettersTree<S> = {},
   A = {},
 >(options: MakeServiceActionsOptions<M, S, G, A>): ServiceStoreDefaultActions<M> & A {

--- a/src/service-store/make-getters.ts
+++ b/src/service-store/make-getters.ts
@@ -19,11 +19,9 @@ type ServiceStoreTypedGetters<M extends BaseModel = BaseModel> = TypedGetters<
   ServiceStoreDefaultGetters<M>
 >
 
-export function makeGetters<
-  M extends BaseModel = BaseModel,
-  S extends StateTree = StateTree,
-  G extends _GettersTree<S> = {},
->(options: MakeServiceGettersOptions<M, S, G>): ServiceStoreDefaultGetters<M> & G {
+export function makeGetters<M extends BaseModel = BaseModel, S extends StateTree = {}, G extends _GettersTree<S> = {}>(
+  options: MakeServiceGettersOptions<M, S, G>,
+): ServiceStoreDefaultGetters<M> & G {
   const defaultGetters: ServiceStoreTypedGetters<M> = {
     // Returns the Feathers service currently assigned to this store.
     service() {

--- a/src/service-store/make-state.ts
+++ b/src/service-store/make-state.ts
@@ -1,19 +1,15 @@
 import { MakeStateOptions, ServiceStoreDefaultState } from './types'
 import { StateTree } from 'pinia'
-import { defaultSharedState } from './define-store'
 import { BaseModel } from './base-model'
 
-export function makeState<
-  M extends BaseModel = BaseModel,
-  S extends StateTree = {}
->(
-  options?: MakeStateOptions<M, S>
+export function makeState<M extends BaseModel = BaseModel, S extends StateTree = {}>(
+  options: MakeStateOptions<M, S>,
 ): () => ServiceStoreDefaultState & S {
   const defaultState: ServiceStoreDefaultState<M> = {
-    clientAlias: options?.clientAlias || defaultSharedState.clientAlias,
-    servicePath: options?.servicePath || defaultSharedState.servicePath,
-    idField: options?.idField || defaultSharedState.idField,
-    tempIdField: options?.tempIdField || defaultSharedState.tempIdField,
+    clientAlias: options.clientAlias,
+    servicePath: options.servicePath,
+    idField: options.idField,
+    tempIdField: options.tempIdField,
     itemsById: {},
     tempsById: {},
     clonesById: {},
@@ -21,7 +17,7 @@ export function makeState<
       Model: {
         find: false,
         count: false,
-        get: false
+        get: false,
       },
     },
     eventLocksById: {
@@ -31,10 +27,10 @@ export function makeState<
       removed: {},
     },
     pagination: {},
-    whitelist: options?.whitelist || defaultSharedState.whitelist,
-    paramsForServer: options?.paramsForServer || defaultSharedState.paramsForServer,
-    skipRequestIfExists: options?.skipRequestIfExists || defaultSharedState.skipRequestIfExists
+    whitelist: options.whitelist,
+    paramsForServer: options.paramsForServer,
+    skipRequestIfExists: options.skipRequestIfExists,
   }
-  const state = options?.state?.()
+  const state = options.state()
   return () => Object.assign(defaultState, state)
 }

--- a/src/service-store/types.ts
+++ b/src/service-store/types.ts
@@ -1,8 +1,8 @@
 import type { Params, Paginated, QueryInfo, HandleEvents } from '../types'
 import type { Ref, ComputedRef } from 'vue-demi'
 import type { Id, Query, NullableId, Application as FeathersClient } from '@feathersjs/feathers'
-import type { StateTree, Store as _Store, StoreDefinition, _GettersTree } from 'pinia'
-import type { MaybeArray, MaybeRef } from '../utility-types'
+import type { StateTree, Store as _Store, StoreDefinition, _GettersTree, DefineStoreOptionsBase } from 'pinia'
+import type { MaybeArray, MaybeRef, TypedActions, TypedGetters } from '../utility-types'
 import { BaseModel } from './base-model'
 import { Find } from '../use-find'
 import { Get } from '../use-get'
@@ -192,9 +192,9 @@ export interface ServiceStoreDefaultActions<M extends BaseModel = BaseModel> {
 export type ServiceOptions<
   Id extends string = any,
   M extends BaseModel = BaseModel,
-  S extends StateTree = Record<string, any>,
-  G extends _GettersTree<S> = Record<string, any>,
-  A = Record<string, any>,
+  S extends StateTree = {},
+  G extends _GettersTree<S> = {},
+  A = {},
 > = Required<
   Pick<
     DefineFeathersStoreOptions<Id, M, S, G, A>,
@@ -572,13 +572,8 @@ export type ServiceStoreDefinition<
   ServiceStoreDefaultActions<M> & A
 >
 
-export type DefineFeathersStoreOptions<
-  Id extends string = string,
-  M extends BaseModel = BaseModel,
-  S extends StateTree = Record<string, any>,
-  G extends _GettersTree<S> = Record<string, any>,
-  A = Record<string, any>,
-> = {
+export interface DefineFeathersStoreOptions<Id extends string, M extends BaseModel, S extends StateTree, G, A>
+  extends DefineStoreOptionsBase<S, _Store<Id, S, G, A>> {
   clientAlias?: string
   idField?: string
   tempIdField?: string
@@ -588,15 +583,15 @@ export type DefineFeathersStoreOptions<
   ssr?: boolean
   servicePath: string
   Model?: ModelStatic<M>
-  id?: Id
   clients?: { [alias: string]: FeathersClient }
   enableEvents?: boolean
   handleEvents?: HandleEvents<M>
   debounceEventsTime?: number
   debounceEventsGuarantee?: boolean
+  id?: Id
   state?: () => S
-  getters?: G
-  actions?: A
+  getters?: TypedGetters<S, G, ServiceStoreDefaultState>
+  actions?: TypedActions<S, G, A, ServiceStoreDefaultState, ServiceStoreDefaultGetters, ServiceStoreDefaultActions>
 }
 
 export interface GetClassParams extends Params {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -5,7 +5,7 @@ import { Ref } from 'vue-demi'
 
 import { HandleEvents } from './types'
 import { Pinia, StateTree, _GettersTree } from 'pinia'
-import { ServiceStore, DefineFeathersStoreOptions } from './service-store/types'
+import { ServiceStore, DefineFeathersStoreOptions, ServiceStoreDefaultState } from './service-store/types'
 
 interface SetupOptions {
   ssr?: boolean | Ref<boolean>
@@ -31,7 +31,24 @@ export function setupFeathersPinia(globalOptions: SetupOptions) {
   function defineStoreWrapper<
     Id extends string,
     M extends BaseModel = BaseModel,
-    S extends StateTree = StateTree,
+    S extends StateTree = {},
+    G extends _GettersTree<S> = {},
+    A = {},
+  >(
+    id: Id,
+    options: Omit<DefineFeathersStoreOptions<Id, M, S, G, A>, 'id'>,
+  ): (pinia?: Pinia) => ServiceStore<Id, M, S, G, A>
+  function defineStoreWrapper<
+    Id extends string,
+    M extends BaseModel = BaseModel,
+    S extends StateTree = {},
+    G extends _GettersTree<S> = {},
+    A = {},
+  >(options: DefineFeathersStoreOptions<Id, M, S, G, A>): (pinia?: Pinia) => ServiceStore<Id, M, S, G, A>
+  function defineStoreWrapper<
+    Id extends string,
+    M extends BaseModel = BaseModel,
+    S extends StateTree = {},
     G extends _GettersTree<S> = {},
     A = {},
   >(

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,4 +1,4 @@
-import { StateTree, _GettersTree, _StoreWithGetters, _StoreWithState } from 'pinia'
+import { StateTree, _GettersTree, _StoreWithGetters, _StoreWithState, PiniaCustomProperties } from 'pinia'
 import { Ref, UnwrapRef } from 'vue-demi'
 
 export type MaybeRef<T> = T | Ref<T>
@@ -13,5 +13,6 @@ export type TypedActions<S, G, A, DefaultS extends StateTree = {}, DefaultG = {}
     A &
       UnwrapRef<DefaultS & S> &
       _StoreWithState<any, DefaultS & S, DefaultG & G, DefaultA & A> &
-      _StoreWithGetters<DefaultG & G> /* & PiniaCustomProperties*/
+      _StoreWithGetters<DefaultG & G> &
+      PiniaCustomProperties
   >


### PR DESCRIPTION
`src/service-store/index.ts` and `src/service-store/define-store.ts` always felt like they should be the other way around. `define-store.ts` now does not import from `index.ts` and `index.ts` just exports.

Also cleaned up `src/index.ts` to not export unusable stuff.

Also defaultStoreOptions & defaultStateOptions setup was weird and overly complicated. This PR makes it a little bit clearer.