### PR TITLE
Use store.$patch() instead of Object.assign() in authStore.authenticate()

### DIFF
--- a/src/define-auth-store.ts
+++ b/src/define-auth-store.ts
@@ -98,7 +98,7 @@ export function defineAuthStore<
     async authenticate(authData: any) {
       try {
         const response = await feathersClient.authenticate(authData)
-        Object.assign(this, { ...response, isAuthenticated: true })
+        this.$patch({ ...response, isAuthenticated: true })
         return this.handleResponse(response) || response
       } catch (error) {
         this.error = error


### PR DESCRIPTION
After updating to `vue3`, the `auth` store was throwing the following error after calling the built-in (original) `authStore.authenticate()` method:

![image](https://user-images.githubusercontent.com/18708856/201986105-c3c7c768-b6f4-4052-aa0b-16c8f2c7b650.png)

Turns out it was due to calling `Object.assign(this, { ...response, isAuthenticated: true })`. The fix was simply using `pinia`'s built-in `$patch`: `this.$patch({ ...response, isAuthenticated: true })`.