### PR TITLE
Use store.$patch() instead of Object.assign() in authStore.authenticate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Feathers-Pinia
-
 <a href="https://feathers-pinia.pages.dev">
   <img src="https://user-images.githubusercontent.com/128857/190210685-df1dbd54-eb41-442e-90c1-d82ca44fc786.jpg" alt="Feathers Pinia Website Hero" />
 </a>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Connect your Feathers API to the elegant data store for Vue
+
 <a href="https://feathers-pinia.pages.dev">
   <img src="https://user-images.githubusercontent.com/128857/190210685-df1dbd54-eb41-442e-90c1-d82ca44fc786.jpg" alt="Feathers Pinia Website Hero" />
 </a>

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -8,9 +8,7 @@ outline: deep
 Feathers-Pinia is the next generation of [Feathers-Vuex](https://vuex.feathersjs.com). The difference is that it's built on [Pinia](https://pinia.esm.dev/): a Vue store with an intuitive API.
 
 ::: tip Introducing Pinia
-PERSONAL OPINION ALERT: [Pinia](https://pinia.esm.dev/) is so simple and elegant. It matches Vue better than Vuex does. The research for Pinia is fueling inspiration for Vuex 5, which means the API is similar to the proposed [Vuex 5 API](https://github.com/kiaking/rfcs/blob/vuex-5/active-rfcs/0000-vuex-5.md).
-
-Using Pinia in your apps will have a few positive effects:
+PERSONAL OPINION ALERT: [Pinia](https://pinia.esm.dev/) is so simple and elegant. It matches Vue better than Vuex does. Using Pinia in your apps will have a few positive effects:
 
 - The clean API requires lower mental overhead to use.
   - No more weird Vuex syntax.
@@ -18,7 +16,6 @@ Using Pinia in your apps will have a few positive effects:
   - Use Composable Stores instead of injected rootState, rootGetters, etc.
 - Lower mental overhead means developers spend more time in a creative space. This usually results in an increase of productivity.
 - You'll have smaller bundle sizes. Not only is Pinia tiny, it's also modular. You don't have to register all of the plugins in a central store. Pinia's architecture enables tree shaking, so only the services needed for the current view need to load.
-- You'll be more ready for the major breaking changes coming in Vuex 5. Vuex was originally written as a Flux/Redux implementation for Vue. It has served its purpose well. With Vuex 5, the team is focusing on making a Vue store.
   :::
 
 ## Compared to Feathers-Vuex

--- a/src/define-auth-store.ts
+++ b/src/define-auth-store.ts
@@ -98,7 +98,7 @@ export function defineAuthStore<
     async authenticate(authData: any) {
       try {
         const response = await feathersClient.authenticate(authData)
-        Object.assign(this, { ...response, isAuthenticated: true })
+        this.$patch({ ...response, isAuthenticated: true })
         return this.handleResponse(response) || response
       } catch (error) {
         this.error = error


### PR DESCRIPTION
**Reopening https://github.com/marshallswain/feathers-pinia/pull/87 for v1 branch...**

---
After updating to `vue3`, the `auth` store was throwing the following error after calling the built-in (original) `authStore.authenticate()` method:

![image](https://user-images.githubusercontent.com/18708856/201986105-c3c7c768-b6f4-4052-aa0b-16c8f2c7b650.png)

Turns out it was due to calling `Object.assign(this, { ...response, isAuthenticated: true })`. The fix was simply using `pinia`'s built-in `$patch`: `this.$patch({ ...response, isAuthenticated: true })`.