### PR TITLE
Remove prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "path": "^0.12.7",
     "pinia": "^2.0.35",
     "postcss-nested": "^6.0.1",
-    "prettier": "^2.8.8",
     "shx": "^0.3.4",
     "tailwindcss": "^3.3.2",
     "typescript": "5.0.4",


### PR DESCRIPTION
1. This crashes prettier in some situations.
2. It's not worth the hell it causes, VSCode's TS formatter is fine!
3. https://antfu.me/posts/why-not-prettier