### PR TITLE
node16: Update missing extensions index.ts

### DIFF
--- a/src/use-auth/index.ts
+++ b/src/use-auth/index.ts
@@ -1,1 +1,1 @@
-export * from './use-auth'
+export * from './use-auth.js'


### PR DESCRIPTION
Some exports are still not found under node16 moduleResolution. In the other NodeNext PR I forgot to fix re-exports... and only addressed imports.

- useAuth
- https://unpkg.com/browse/feathers-pinia@3.0.4/dist/stores/index.d.ts
- https://unpkg.com/browse/feathers-pinia@3.0.4/dist/use-find-get/index.d.ts
- https://unpkg.com/browse/feathers-pinia@3.0.4/dist/utils/index.d.ts