### PR TITLE
feat: Add type annotations to PiniaService

### DIFF
--- a/src/create-pinia-client.ts
+++ b/src/create-pinia-client.ts
@@ -17,7 +17,7 @@ interface SetupInstanceUtils {
   servicePath?: string
 }
 
-interface PiniaServiceConfig {
+export interface PiniaServiceConfig {
   idField?: string
   defaultLimit?: number
   syncWithStorage?: boolean | string[]
@@ -32,7 +32,7 @@ interface PiniaServiceConfig {
   customSiftOperators?: Record<string, any>
 }
 
-interface CreatePiniaClientConfig extends PiniaServiceConfig {
+export interface CreatePiniaClientConfig extends PiniaServiceConfig {
   idField: string
   pinia: any
   ssr?: boolean
@@ -40,11 +40,11 @@ interface CreatePiniaClientConfig extends PiniaServiceConfig {
   services?: Record<string, PiniaServiceConfig>
 }
 
-type CreatePiniaServiceTypes<T extends { [key: string]: FeathersService }> = {
+export type CreatePiniaServiceTypes<T extends { [key: string]: FeathersService }> = {
   [Key in keyof T]: PiniaService<T[Key]> & T[Key]
 }
 
-interface AppExtensions {
+export interface AppExtensions {
   storeAssociated: (data: any, config: Record<string, string>) => void
   clearStorage: () => void
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types.js'
 
 export { createPiniaClient } from './create-pinia-client.js'
+export type * from './create-pinia-client.js'
 export { PiniaService } from './create-pinia-service'
 export { OFetch } from './feathers-ofetch.js'
 

--- a/src/modeling/use-feathers-instance.ts
+++ b/src/modeling/use-feathers-instance.ts
@@ -51,7 +51,7 @@ export function useServiceInstance<M extends AnyData, S extends Service, P exten
       const id = this[store.idField]
       if (id === undefined)
         throw new BadRequest('the item has no id')
-      return service.patch(id, this, params).then(result => merge(this, result))
+      return (service as FeathersService).patch(id as any, this as any, params as any).then(result => merge(this, result))
     },
     remove(this: M, params?: P): Promise<M> {
       if (this.__isTemp) {
@@ -60,7 +60,7 @@ export function useServiceInstance<M extends AnyData, S extends Service, P exten
       }
       else {
         const id = this[store.idField]
-        return service.remove(id, params).then(result => merge(this, result))
+        return (service as FeathersService).remove(id, params).then(result => merge(this, result))
       }
     },
   })

--- a/src/use-find-get/use-find.ts
+++ b/src/use-find-get/use-find.ts
@@ -10,15 +10,15 @@ import { itemsFromPagination } from './utils.js'
 import { usePageData } from './utils-pagination.js'
 import type { UseFindGetDeps, UseFindOptions, UseFindParams } from './types.js'
 
-export function useFind(params: ComputedRef<UseFindParams | null>, options: UseFindOptions = {}, deps: UseFindGetDeps) {
+export function useFind<M = AnyData>(params: ComputedRef<UseFindParams | null>, options: UseFindOptions = {}, deps: UseFindGetDeps) {
   const { pagination, debounce = 100, immediate = true, watch: _watch = true, paginateOn = 'client' } = options
   const { service } = deps
   const { store } = service
 
   /** PARAMS **/
   const qid = computed(() => params.value?.qid || 'default')
-  const limit = pagination?.limit || ref(params.value?.query?.$limit || store.defaultLimit)
-  const skip = pagination?.skip || ref(params.value?.query?.$skip || 0)
+  const limit = pagination?.limit || ref(params.value?.query?.$limit || store.defaultLimit as number)
+  const skip = pagination?.skip || ref(params.value?.query?.$skip || 0 as number)
 
   const paramsWithPagination = computed(() => {
     const query = deepUnref(params.value?.query || {})
@@ -67,7 +67,7 @@ export function useFind(params: ComputedRef<UseFindParams | null>, options: UseF
     return params
   })
 
-  const data = computed(() => {
+  const data = computed<M[]>(() => {
     if (paginateOn === 'server') {
       const values = itemsFromPagination(store, service, cachedParams.value)
       return values
@@ -94,7 +94,7 @@ export function useFind(params: ComputedRef<UseFindParams | null>, options: UseF
     const beforeCurrent = allItems.slice(0, adjustedIndex)
     return beforeCurrent
   })
-  const allLocalData = computed(() => {
+  const allLocalData = computed<M[]>(() => {
     const whichQuery = isPending.value ? cachedQuery.value : currentQuery.value
     if (whichQuery == null && paginateOn !== 'client')
       return []
@@ -222,7 +222,7 @@ export function useFind(params: ComputedRef<UseFindParams | null>, options: UseF
   }
 
   /** Pagination Data **/
-  const total = computed(() => {
+  const total = computed<number>(() => {
     if (['server', 'hybrid'].includes(paginateOn)) {
       const whichQuery = currentQuery.value || cachedQuery.value
       return whichQuery?.total || 0
@@ -275,7 +275,7 @@ export function useFind(params: ComputedRef<UseFindParams | null>, options: UseF
       setTimeout(() => {
         ref(total.value)
       }, 0)
-      return store.isSsr
+      return store.isSsr as boolean
     }), // ComputedRef<boolean>
     qid, // WritableComputedRef<string>
 

--- a/src/use-find-get/use-get.ts
+++ b/src/use-find-get/use-get.ts
@@ -7,7 +7,7 @@ import type { UseFindGetDeps, UseGetParams } from './types.js'
 
 type MaybeComputed<M> = ComputedRef<M> | MaybeRef<M>
 
-export function useGet(_id: MaybeComputed<Id | null>,
+export function useGet<M = AnyData>(_id: MaybeComputed<Id | null>,
   _params: MaybeRef<UseGetParams> = ref({}),
   deps: UseFindGetDeps) {
   const { service } = deps
@@ -18,7 +18,7 @@ export function useGet(_id: MaybeComputed<Id | null>,
 
   /** ID & PARAMS **/
   const { immediate = true, watch: _watch = true } = params.value
-  const isSsr = computed(() => service.store.isSsr)
+  const isSsr = computed<boolean>(() => service.store.isSsr)
 
   /** REQUEST STATE **/
   const isPending = ref(false)
@@ -31,7 +31,7 @@ export function useGet(_id: MaybeComputed<Id | null>,
   const mostRecentId = computed(() => {
     return ids.value.length && ids.value[ids.value.length - 1]
   })
-  const data = computed(() => {
+  const data = computed<M | null>(() => {
     if (isPending.value && mostRecentId.value != null) {
       const result = service.store.getFromStore(mostRecentId.value, params).value
       return result

--- a/tests/instance-api/instance-patch-diffing.test.ts
+++ b/tests/instance-api/instance-patch-diffing.test.ts
@@ -14,7 +14,7 @@ afterEach(() => resetService(service))
 describe('instance patch diffing', () => {
   test('diff by default ', async () => {
     const contact = await service.new({}).save()
-    const clone = contact.clone()
+    const clone = contact.clone() as any
     clone.name = 'it was the size of texas'
     clone.isComplete = true
 
@@ -45,7 +45,7 @@ describe('instance patch diffing', () => {
 
   test('diff string overrides the default diffing algorithm', async () => {
     const contact = await service.new({}).save()
-    const clone = contact.clone()
+    const clone = contact.clone() as any
     clone.name = 'it was the size of texas'
     clone.isComplete = true
 
@@ -77,7 +77,7 @@ describe('instance patch diffing', () => {
 
   test('diff array of strings', async () => {
     const contact = await service.new({}).save()
-    const clone = contact.clone()
+    const clone = contact.clone() as any
     clone.name = 'it was the size of texas'
     clone.test = false
     clone.foo = new Date() // won't get diffed because it's excluded in params.diff
@@ -93,7 +93,7 @@ describe('instance patch diffing', () => {
 
   test('diff array of strings, only one value changes', async () => {
     const contact = await service.new({}).save()
-    const clone = contact.clone()
+    const clone = contact.clone() as any
     clone.name = 'it was the size of texas'
     clone.test = true
     clone.foo = new Date() // won't get diffed because it's excluded in params.diff
@@ -109,7 +109,7 @@ describe('instance patch diffing', () => {
 
   test('diff with object', async () => {
     const contact = await service.new({}).save()
-    const clone = contact.clone()
+    const clone = contact.clone() as any
     clone.name = 'it was the size of texas'
     clone.test = false
     clone.foo = new Date() // won't get diffed because it's excluded in params.diff
@@ -124,7 +124,7 @@ describe('instance patch diffing', () => {
   })
 
   test('diff and with as string', async () => {
-    const contact = await service.new({ test: 'foo' }).save()
+    const contact = await service.new({ test: 'foo' } as any).save()
     const clone = contact.clone()
     clone.name = 'it was the size of texas'
 
@@ -139,7 +139,7 @@ describe('instance patch diffing', () => {
 
   test('diff and with as array', async () => {
     const contact = await service.new({}).save()
-    const clone = contact.clone()
+    const clone = contact.clone() as any
     clone.name = 'it was the size of texas'
     clone.test = false
 
@@ -154,7 +154,7 @@ describe('instance patch diffing', () => {
 
   test('diff and with as object', async () => {
     const contact = await service.new({}).save()
-    const clone = contact.clone()
+    const clone = contact.clone() as any
     clone.name = 'it was the size of texas'
     clone.test = true
 

--- a/tests/instance-api/instance-temps.test.ts
+++ b/tests/instance-api/instance-temps.test.ts
@@ -77,7 +77,7 @@ describe('Temporary Records', () => {
 
   test('find getter returns temps when temps param is true', async () => {
     service.new({ name: 'this is a test' }).createInStore()
-    const contact$ = service.findInStore({ query: {}, temps: true })
+    const contact$ = service.findInStore({ query: {}, temps: true } as any)
     expect(contact$.data.length).toBe(13)
   })
 

--- a/tests/stores/use-data-store-storage.test.ts
+++ b/tests/stores/use-data-store-storage.test.ts
@@ -26,32 +26,32 @@ describe('useModelInstance temps', () => {
   })
 
   test('not added to Model store by default', () => {
-    service.new({ description: 'foo', isComplete: true })
+    service.new({ description: 'foo', isComplete: true } as any)
     expect(service.store.items.length).toBe(0)
     expect(service.store.temps.length).toBe(0)
     expect(service.store.clones.length).toBe(0)
   })
 
   test('call createInStore without id to add to tempStore', () => {
-    const task = service.new({ description: 'foo', isComplete: true }).createInStore()
+    const task = service.new({ description: 'foo', isComplete: true } as any).createInStore()
     expect(service.store.temps.length).toBe(1)
     expect(service.store.temps[0]).toBe(task)
   })
 
   test('call createInStore with id to add to itemStore', () => {
-    const task = service.new({ _id: '1', description: 'foo', isComplete: true }).createInStore()
+    const task = service.new({ _id: '1', description: 'foo', isComplete: true } as any).createInStore()
     expect(service.store.items.length).toBe(1)
     expect(service.store.items[0]).toBe(task)
   })
 
   test('call removeFromStore on temp', () => {
-    const task = service.new({ description: 'foo', isComplete: true }).createInStore()
+    const task = service.new({ description: 'foo', isComplete: true } as any).createInStore()
     task.removeFromStore()
     expect(service.store.temps.length).toBe(0)
   })
 
   test('call removeFromStore on item', () => {
-    const task = service.new({ _id: '1', description: 'foo', isComplete: true }).createInStore()
+    const task = service.new({ _id: '1', description: 'foo', isComplete: true } as any).createInStore()
     task.removeFromStore()
     expect(service.store.items.length).toBe(0)
   })

--- a/tests/use-find-get/use-find-hybrid.test.ts
+++ b/tests/use-find-get/use-find-hybrid.test.ts
@@ -530,7 +530,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate + 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 
@@ -547,7 +547,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate + 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 
@@ -563,7 +563,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate - 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 
@@ -580,7 +580,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate - 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 
@@ -596,7 +596,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate - 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 
@@ -613,7 +613,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate - 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 
@@ -629,7 +629,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate - 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 
@@ -652,7 +652,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate - 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 
@@ -674,7 +674,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate - 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 
@@ -702,7 +702,7 @@ describe('useFind', () => {
 
     await contacts$.request
     expect(contacts$.data.length).toBe(10)
-    const first = contacts$.data[0]
+    const first = contacts$.data[0] as any
     const birthdate = first.birthdate - 1
     const copyOfFirst = { _id: 100, name: 'Steve', age: first.age, birthdate, added: true }
 


### PR DESCRIPTION
Hi,

Following issues I had with types (see https://github.com/marshallswain/feathers-pinia/issues/143 & https://github.com/marshallswain/feathers-pinia/issues/144), here is a proposal to improve the situation a bit.

~~There remains type errors is the tests, mostly because the contact model is extended (with birthdate and description)~~
- ~~tests/instance-api/instance-patch-diffing.test.ts~~
- ~~tests/instance-api/instance-temps.test.ts~~
- ~~tests/stores/use-data-store-storage.test.ts~~
- ~~tests/use-find-get/use-find-hybrid.test.ts~~

Solved

This is mostly a quick fix, I found the typing is still a bit lacking, if you want I can look deeper into it and try to annotate the stores and composables.

Cheers,