### PR TITLE
feat(normalize-find): provide default context.result for find

### DIFF
--- a/src/hooks/6-normalize-find.ts
+++ b/src/hooks/6-normalize-find.ts
@@ -20,8 +20,13 @@ export function normalizeFind() {
 
     next && await next()
 
-    // if (context.method === 'find' && !context.result?.data) {
-    // context.result = { data: context.result }
-    // }
+    if (context.method === 'find' && !context.result?.data) {
+      context.result = {
+        data: [],
+        limit: context.params.$limit,
+        skip: context.params.$skip,
+        total: 0,
+      }
+    }
   }
 }


### PR DESCRIPTION
provides a default `context.result` value when there is no `data` or context.result is null.