### PR TITLE
fix: update types for `findOneInStore`

### DIFF
--- a/src/create-pinia-service.ts
+++ b/src/create-pinia-service.ts
@@ -155,7 +155,7 @@ export class PiniaService<Svc extends FeathersService> {
   /**
    * find a single record in the local store by query.
    */
-  findOneInStore(params?: MaybeRef<SvcParams<Svc>>): SvcModel<Svc>
+  findOneInStore(params?: MaybeRef<SvcParams<Svc>>): ComputedRef<SvcModel<Svc>>
   findOneInStore(params?: MaybeRef<Params<Query>>) {
     const result = this.store.findOneInStore(params)
     return result


### PR DESCRIPTION
Service function for `findOneInStore` returns a `ComputedRef` ([src/store/local-queries.ts](https://github.com/marshallswain/feathers-pinia/blob/6c7cd85b217c59ba80341ee14b79ed9ae69c7b8e/src/stores/local-queries.ts#L125-L127)), which isn't reflected in the current type signature.