### PR TITLE
fix: useFind default typing broken

### DIFF
--- a/src/create-pinia-service.ts
+++ b/src/create-pinia-service.ts
@@ -233,18 +233,18 @@ export class PiniaService<Svc extends FeathersService> {
 
   /* hybrid methods */
 
-  useFind<M>(params: ComputedRef<UseFindParams | null>, options?: UseFindOptions) {
+  useFind<M = SvcModel<Svc>>(params: ComputedRef<UseFindParams | null>, options?: UseFindOptions) {
     const _params = isRef(params) ? params : ref(params)
-    return useFind<M | SvcModel<Svc>>(_params as ComputedRef<UseFindParams | null>, options, { service: this })
+    return useFind<M>(_params as ComputedRef<UseFindParams | null>, options, { service: this })
   }
 
-  useGet<M>(id: MaybeRef<Id | null>, params: MaybeRef<UseGetParams> = ref({})) {
+  useGet<M = SvcModel<Svc>>(id: MaybeRef<Id | null>, params: MaybeRef<UseGetParams> = ref({})) {
     const _id = isRef(id) ? id : ref(id)
     const _params = isRef(params) ? params : ref(params)
-    return useGet<M | SvcModel<Svc>>(_id, _params, { service: this })
+    return useGet<M>(_id, _params, { service: this })
   }
 
-  useGetOnce<M>(_id: MaybeRef<Id | null>, params: MaybeRef<UseGetParams> = {}) {
+  useGetOnce<M = SvcModel<Svc>>(_id: MaybeRef<Id | null>, params: MaybeRef<UseGetParams> = {}) {
     const _params = isRef(params) ? params : ref(params)
     Object.assign(_params.value, { immediate: false })
     const results = this.useGet<M>(_id, _params)


### PR DESCRIPTION
 just pulled my hair out comparing the setup from project A to project B, where the data field returned from useFind in project B was not inferring the service type, and instead insisting on unknown[], finally looked at the package versions, long behold project B is running on the latest and A in on 4.4.0 😅 

looks like this is the culprit: https://github.com/marshallswain/feathers-pinia/commit/4804ef4aaa842d52c3f21d491bccb5bcf5a33f09

if you don't explicitly provide a type for M, it assumes it's unknown. I managed to fix it by setting a default on the declaration <M = SvcModel<Svc>>

Also taking out the ambiguity of the type, either its the override or the default type, not both