### PR TITLE
fix: diff ignore false

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -65,11 +65,15 @@ export function pickDiff(obj: any, diffDef: DiffDefinition) {
 }
 
 export function diff(dest: AnyData, source: AnyData, diffDef?: DiffDefinition) {
+  // If diffDef is false, return the entire source object (turn off diffing)
+  if (diffDef === false)
+    return source
+
   const originalVal = pickDiff(dest, diffDef)
   const cloneVal = pickDiff(source, diffDef)
 
   // If diff was an object, merge the values into the cloneVal
-  if (typeof diffDef !== 'string' && !Array.isArray(diffDef))
+  if (typeof diffDef === 'object' && diffDef !== null && !Array.isArray(diffDef))
     Object.assign(cloneVal, diffDef)
 
   const areEqual = isEqual(originalVal, cloneVal)

--- a/tests/instance-api/instance-patch-diffing.test.ts
+++ b/tests/instance-api/instance-patch-diffing.test.ts
@@ -40,7 +40,9 @@ describe('instance patch diffing', () => {
     await clone.save({ diff: false })
 
     const callData = hook.mock.results[0].value.data
-    expect(callData).toEqual({ name: 'it was the size of texas' })
+    // When diff: false, the entire clone object should be sent
+    expect(callData).toHaveProperty('name', 'it was the size of texas')
+    expect(callData).toHaveProperty('_id', contact._id)
   })
 
   test('diff string overrides the default diffing algorithm', async () => {

--- a/tests/utils/diff.test.ts
+++ b/tests/utils/diff.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest'
+import { diff } from '../../src/utils/utils.js'
+
+describe('diff function', () => {
+  test('should return entire source object when diffDef is false', () => {
+    const original = { id: 1, name: 'John', age: 30 }
+    const updated = { id: 1, name: 'Jane', age: 25, city: 'New York' }
+
+    const result = diff(original, updated, false)
+
+    expect(result).toEqual(updated)
+  })
+
+  test('should perform normal diffing when diffDef is undefined', () => {
+    const original = { id: 1, name: 'John', age: 30 }
+    const updated = { id: 1, name: 'Jane', age: 25 }
+
+    const result = diff(original, updated)
+
+    expect(result).toEqual({ name: 'Jane', age: 25 })
+  })
+
+  test('should handle diffDef as string', () => {
+    const original = { id: 1, name: 'John', age: 30 }
+    const updated = { id: 1, name: 'Jane', age: 25 }
+
+    const result = diff(original, updated, 'name')
+
+    expect(result).toEqual({ name: 'Jane' })
+  })
+
+  test('should handle diffDef as array', () => {
+    const original = { id: 1, name: 'John', age: 30 }
+    const updated = { id: 1, name: 'Jane', age: 25 }
+
+    const result = diff(original, updated, ['name'])
+
+    expect(result).toEqual({ name: 'Jane' })
+  })
+
+  test('should handle diffDef as object', () => {
+    const original = { id: 1, name: 'John', age: 30 }
+    const updated = { id: 1, name: 'Jane', age: 25 }
+
+    const result = diff(original, updated, { extraProp: 'test' })
+
+    // When diffDef is an object, it merges with the object keys, not the source
+    expect(result).toEqual({ extraProp: 'test' })
+  })
+
+  test('should return empty object when no changes', () => {
+    const original = { id: 1, name: 'John', age: 30 }
+    const updated = { id: 1, name: 'John', age: 30 }
+
+    const result = diff(original, updated)
+
+    expect(result).toEqual({})
+  })
+
+  test('should return entire object when no changes with false diffDef', () => {
+    const original = { id: 1, name: 'John', age: 30 }
+    const updated = { id: 1, name: 'John', age: 30 }
+
+    // Even with false, if objects are identical, return the entire object
+    const result = diff(original, updated, false)
+
+    expect(result).toEqual(updated)
+  })
+})


### PR DESCRIPTION
### Problem
The diff algorithm wasn't properly handling `diffDef: false`, even though it's documented as a way to "turn off diffing and send everything". When `diff: false` was passed, the function was still performing diffing instead of sending the entire object.

### Solution
- Modified the `diff` function in `utils.ts` to explicitly check for `diffDef === false` and return the entire source object
- Updated type checking logic to properly handle the false case alongside object-type diffDef parameters