### PR TITLE
fix #171 Wrong implementation of countInStore-Service-Method

### DIFF
--- a/src/create-pinia-service.ts
+++ b/src/create-pinia-service.ts
@@ -175,7 +175,7 @@ export class PiniaService<Svc extends FeathersService> {
   /**
    * count records matching a query in the store.
    */
-  countInStore(params?: MaybeRef<SvcParams<Svc>>): Paginated<never>
+  countInStore(params?: MaybeRef<SvcParams<Svc>>): ComputedRef<number>
   countInStore(params?: MaybeRef<Params<Query>>) {
     const result = this.store.countInStore(params)
     return result


### PR DESCRIPTION
FIX #171  
The `countInStore` service method had an incorrect TypeScript type signature that claimed to return `Paginated<never>`, but the actual implementation returns `ComputedRef<number>`. This caused type errors for developers using the method.

